### PR TITLE
[BUGFIX] Fix array access on RecordInterface in ContentPreviewRenderer for TYPO3 v14

### DIFF
--- a/Classes/Backend/Preview/ContentPreviewRenderer.php
+++ b/Classes/Backend/Preview/ContentPreviewRenderer.php
@@ -13,14 +13,18 @@ namespace B13\Codeblock\Backend\Preview;
  */
 
 use TYPO3\CMS\Backend\View\BackendLayout\Grid\GridColumnItem;
+use TYPO3\CMS\Core\Domain\RecordInterface;
 
 class ContentPreviewRenderer extends \TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer
 {
     public function renderPageModulePreviewContent(GridColumnItem $item): string
     {
         $record = $item->getRecord();
-        if (trim($record['bodytext'] ?? '') !== '') {
-            return $this->linkEditContent(nl2br(htmlentities($record['bodytext'])), $record) . '<br />';
+        $bodytext = $record instanceof RecordInterface
+            ? (string)($record->get('bodytext') ?? '')
+            : (string)($record['bodytext'] ?? '');
+        if (trim($bodytext) !== '') {
+            return $this->linkEditContent(nl2br(htmlentities($bodytext)), $record) . '<br />';
         }
         return parent::renderPageModulePreviewContent($item);
     }


### PR DESCRIPTION
## Problem

In TYPO3 v14, `GridColumnItem::getRecord()` returns a `RecordInterface` object instead of an array. The `ContentPreviewRenderer::renderPageModulePreviewContent()` method used PHP array access syntax on the record:

```php
if (trim($record['bodytext'] ?? '') !== '') {
    return $this->linkEditContent(nl2br(htmlentities($record['bodytext'])), $record) . '<br />';
}
```

- The condition silently returned `null` (due to `??`) but the inner expression `$record['bodytext']` (without `??`) would throw `Cannot use object of type TYPO3\CMS\Core\Domain\Record as array` if the condition ever evaluated to true.
- Additionally, `RecordInterface` never implements `ArrayAccess`, making the `??` fallback behaviour version-dependent.

## Fix

Detect whether the record is a `RecordInterface` (TYPO3 v14+) and use `->get()` in that case, keeping the original array access path for TYPO3 v10–v13 compatibility. Note that `linkEditContent()` also had its signature updated in v14 to accept `RecordInterface` instead of `array`, so passing `$record` directly works correctly in all supported versions.

## Compatibility

- TYPO3 v10.4 / v11.5 / v12.x / v13.x: `$record` is an array → uses `$record['bodytext']` path
- TYPO3 v14.x: `$record` is a `RecordInterface` → uses `$record->get('bodytext')` path